### PR TITLE
Add Jenkinsfile for .NET restore, build, and test pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,21 @@
+pipeline {
+    agent any
+  
+    stages {
+        stage('Restore Dependencies') {
+            steps {
+                bat 'dotnet restore'
+            }
+        }
+        stage('Build') {
+            steps {
+                bat 'dotnet build --no-restore'
+            }
+        }
+        stage('Run Tests') {
+            steps {
+                bat 'dotnet test --no-build --verbosity normal'
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new Jenkinsfile that defines a simple CI pipeline for a .NET project. The pipeline performs the following steps on any available agent using Windows batch commands:
- Restore Dependencies: Executes dotnet restore to retrieve all required NuGet packages.
- Build: Compiles the project using dotnet build --no-restore, skipping the restore step since it's already completed.
- Run Tests: Runs tests using dotnet test --no-build --verbosity normal for clear output without rebuilding.